### PR TITLE
Enabled building on linux

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,17 +1,51 @@
 extern crate gcc;
 
-fn main() {
-    // These next 2 lines should only be for OS X and other platforms need
-    // to do something different.
+use gcc::Config;
+use std::process::Command;
+
+fn get_llvm_output(arg: &str) -> String {
+    let res = Command::new("llvm-config").arg(arg).output().unwrap();
+    if !res.status.success() {
+        panic!("Could not run \"llvm-config {}\": {}", arg, res.status.code().unwrap());
+    }
+    String::from_utf8(res.stdout).unwrap().trim().to_string()
+}
+
+#[cfg(target_os = "macos")]
+fn get_config() -> Config {
     println!("cargo:rustc-flags=-l framework=LLDB");
     println!("cargo:rustc-flags=-L framework=/Applications/Xcode.app/Contents/SharedFrameworks");
-    gcc::Config::new()
+    let mut res = gcc::Config::new();
+    res
+        .include(env!("LLVM_ROOT").to_owned() + "/tools/lldb/include")
+        .include(env!("LLVM_ROOT").to_owned() + "/include")
+        .include(env!("LLVM_BUILD_ROOT").to_owned() + "/include");
+    res
+}
+
+#[cfg(target_os = "linux")]
+fn get_config() -> Config {
+    let llvm_headers_path = get_llvm_output("--includedir");
+    let llvm_lib_path = get_llvm_output("--libdir");
+    let llvm_version = get_llvm_output("--version").split('.').take(2).collect::<Vec<&str>>().join(".");
+    let lib_name = ["lldb-", &llvm_version].join("");
+    println!("cargo:rustc-link-search={}", llvm_lib_path);
+    println!("cargo:rustc-link-lib={}", lib_name);
+    let mut res = gcc::Config::new();
+    res.include(llvm_headers_path);
+    res
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "linux")))]
+fn get_config() -> Config {
+    panic!("Only MacOS and Linux are supported currently");
+}
+
+fn main() {
+    get_config()
         .cpp(true)
         .flag("-std=c++14")
         .include("src")
-        .include(env!("LLVM_ROOT").to_owned() + "/tools/lldb/include")
-        .include(env!("LLVM_ROOT").to_owned() + "/include")
-        .include(env!("LLVM_BUILD_ROOT").to_owned() + "/include")
         .file("src/lldb/Bindings/SBAddressBinding.cpp")
         .file("src/lldb/Bindings/SBAttachInfoBinding.cpp")
         .file("src/lldb/Bindings/SBBlockBinding.cpp")


### PR DESCRIPTION
Only tested on Ubuntu 16.04 64-bit with native "lldb", "llvm" and "liblldb-3.8-dev" packages installed.

There is an issue with system libraries:

```
$ ls -l `llvm-config --libdir` | grep lldb | grep .so
lrwxrwxrwx 1 root root      14 июл 12 16:40 liblldb-3.8.0.so -> liblldb-3.8.so
lrwxrwxrwx 1 root root      16 июл 12 16:40 liblldb-3.8.so -> liblldb-3.8.so.1
lrwxrwxrwx 1 root root      14 июл 12 16:40 liblldb.so -> liblldb-3.8.so
lrwxrwxrwx 1 root root      39 июл 12 16:40 liblldb.so.1 -> ../../x86_64-linux-gnu/liblldb-3.8.so.1
```

As you can see, all three needed files (`liblldb.so`, `liblldb-3.8.so` and `liblldb-3.8.0.so`) point to non-existent `liblldb-3.8.so.1` file. Nevertheless,

```
$ ld -l lldb
ld: cannot find -llldb
$ ld -l lldb-3.8
ld: warning: cannot find entry symbol _start; not setting start address
$ ld -l lldb-3.8.0
ld: cannot find -llldb-3.8.0
```

for some reason `ld` finds `lldb-3.8` package somehow. Therefore, I included code that creates name of this library from `llvm-config --version`.

Only tested this change on Ubuntu 16.04 64 bit.
