### PR TITLE
fix: calling SBStructuredDataSetFromJSON will cause linkage error

### DIFF
--- a/src/lldb/Bindings/SBStructuredDataBinding.cpp
+++ b/src/lldb/Bindings/SBStructuredDataBinding.cpp
@@ -40,7 +40,7 @@ void SBStructuredDataClear(SBStructuredDataRef instance) {
   unwrapped->Clear();
 }
 
-SBErrorRef SBStructureDataSetFromJSON(SBStructuredDataRef instance,
+SBErrorRef SBStructuredDataSetFromJSON(SBStructuredDataRef instance,
                                       SBStreamRef stream) {
   SBStructuredData *unwrapped = reinterpret_cast<SBStructuredData *>(instance);
   return reinterpret_cast<SBErrorRef>(new SBError(

--- a/src/lldb/Bindings/SBStructuredDataBinding.cpp
+++ b/src/lldb/Bindings/SBStructuredDataBinding.cpp
@@ -47,7 +47,7 @@ SBErrorRef SBStructuredDataSetFromJSON(SBStructuredDataRef instance,
       unwrapped->SetFromJSON(*reinterpret_cast<SBStream *>(stream))));
 }
 
-SBErrorRef SBStructureDataSetFromJSON2(SBStructuredDataRef instance,
+SBErrorRef SBStructuredDataSetFromJSON2(SBStructuredDataRef instance,
                                        const char *json) {
   SBStructuredData *unwrapped = reinterpret_cast<SBStructuredData *>(instance);
   return reinterpret_cast<SBErrorRef>(

--- a/src/lldb/Bindings/SBStructuredDataBinding.h
+++ b/src/lldb/Bindings/SBStructuredDataBinding.h
@@ -30,7 +30,7 @@ LLDB_API void SBStructuredDataClear(SBStructuredDataRef instance);
 LLDB_API SBErrorRef SBStructuredDataSetFromJSON(SBStructuredDataRef instance,
                                                 SBStreamRef stream);
 
-LLDB_API SBErrorRef SBStructureDataSetFromJSON2(SBStructuredDataRef instance,
+LLDB_API SBErrorRef SBStructuredDataSetFromJSON2(SBStructuredDataRef instance,
                                                 const char *json);
 
 LLDB_API SBErrorRef SBStructuredDataGetAsJSON(SBStructuredDataRef instance,


### PR DESCRIPTION
Actually, I found this error while building for windows with several patches on local. I'll send patches for building on windows in another PR.